### PR TITLE
move git.apache to github.com

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/beltran/gohive
 
 require (
-	git.apache.org/thrift.git v0.0.0-20181019115558-cd829a0b9a5c
+	github.com/apache/thrift.git v0.0.0-20181019115558-cd829a0b9a5c
 	github.com/beltran/gosasl v0.0.0-20181023043315-01c4c2ce6a51
 	github.com/beltran/gssapi v0.0.0-20180807003338-598f9f3b2878 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/beltran/gohive
 
 require (
-	github.com/apache/thrift.git v0.0.0-20181019115558-cd829a0b9a5c
+	github.com/apache/thrift v0.0.0-20181019115558-cd829a0b9a5c
 	github.com/beltran/gosasl v0.0.0-20181023043315-01c4c2ce6a51
 	github.com/beltran/gssapi v0.0.0-20180807003338-598f9f3b2878 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/apche/thrift.git v0.0.0-20181019115558-cd829a0b9a5c h1:9PmU5RntPkrcwpEhCkzh89R8g23jsuEw6OtY7k9wWUg=
-github.com/apache/thrift.git v0.0.0-20181019115558-cd829a0b9a5c/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+github.com/apache/thrift v0.0.0-20181019115558-cd829a0b9a5c h1:9PmU5RntPkrcwpEhCkzh89R8g23jsuEw6OtY7k9wWUg=
+github.com/apache/thrift v0.0.0-20181019115558-cd829a0b9a5c/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/beltran/gosasl v0.0.0-20181023043315-01c4c2ce6a51 h1:4GvVCQFfMBsrCaTYR7E506OkKBZ/1AI+rc+oIgl2rm4=
 github.com/beltran/gosasl v0.0.0-20181023043315-01c4c2ce6a51/go.mod h1:4bpdWW6Q7hC2xAn+KT/ueCo1FoklhOMmEeHLhZso7po=
 github.com/beltran/gssapi v0.0.0-20180807003338-598f9f3b2878 h1:3xXWpeNMPRcQlbGdyfIdBHh9eD5TQgMWlZlHZ2luTwo=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-git.apache.org/thrift.git v0.0.0-20181019115558-cd829a0b9a5c h1:9PmU5RntPkrcwpEhCkzh89R8g23jsuEw6OtY7k9wWUg=
-git.apache.org/thrift.git v0.0.0-20181019115558-cd829a0b9a5c/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+github.com/apache/thrift.git v0.0.0-20181019115558-cd829a0b9a5c h1:9PmU5RntPkrcwpEhCkzh89R8g23jsuEw6OtY7k9wWUg=	github.com/apache/thrift.git v0.0.0-20181019115558-cd829a0b9a5c h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+github.com/apache/thrift.git v0.0.0-20181019115558-cd829a0b9a5c/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/beltran/gosasl v0.0.0-20181023043315-01c4c2ce6a51 h1:4GvVCQFfMBsrCaTYR7E506OkKBZ/1AI+rc+oIgl2rm4=
 github.com/beltran/gosasl v0.0.0-20181023043315-01c4c2ce6a51/go.mod h1:4bpdWW6Q7hC2xAn+KT/ueCo1FoklhOMmEeHLhZso7po=
 github.com/beltran/gssapi v0.0.0-20180807003338-598f9f3b2878 h1:3xXWpeNMPRcQlbGdyfIdBHh9eD5TQgMWlZlHZ2luTwo=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/apache/thrift.git v0.0.0-20181019115558-cd829a0b9a5c h1:9PmU5RntPkrcwpEhCkzh89R8g23jsuEw6OtY7k9wWUg=	github.com/apache/thrift.git v0.0.0-20181019115558-cd829a0b9a5c h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+github.com/apche/thrift.git v0.0.0-20181019115558-cd829a0b9a5c h1:9PmU5RntPkrcwpEhCkzh89R8g23jsuEw6OtY7k9wWUg=
 github.com/apache/thrift.git v0.0.0-20181019115558-cd829a0b9a5c/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/beltran/gosasl v0.0.0-20181023043315-01c4c2ce6a51 h1:4GvVCQFfMBsrCaTYR7E506OkKBZ/1AI+rc+oIgl2rm4=
 github.com/beltran/gosasl v0.0.0-20181023043315-01c4c2ce6a51/go.mod h1:4bpdWW6Q7hC2xAn+KT/ueCo1FoklhOMmEeHLhZso7po=

--- a/hive.go
+++ b/hive.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift.git/lib/go/thrift"
 	"github.com/beltran/gohive/hiveserver"
 	"github.com/beltran/gosasl"
 )

--- a/hive.go
+++ b/hive.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/apache/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/beltran/gohive/hiveserver"
 	"github.com/beltran/gosasl"
 )

--- a/hiveserver/HiveServer-consts.go
+++ b/hiveserver/HiveServer-consts.go
@@ -7,8 +7,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
 	"reflect"
+
+	"github.com/apache/thrift.git/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/hiveserver/HiveServer-consts.go
+++ b/hiveserver/HiveServer-consts.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/apache/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/hiveserver/HiveServer.go
+++ b/hiveserver/HiveServer.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/apche/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/hiveserver/HiveServer.go
+++ b/hiveserver/HiveServer.go
@@ -9,8 +9,9 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
 	"reflect"
+
+	"github.com/apche/thrift.git/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/sasl_transport.go
+++ b/sasl_transport.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/beltran/gosasl"
 	"io"
+
+	"github.com/apache/thrift.git/lib/go/thrift"
+	"github.com/beltran/gosasl"
 )
 
 const (

--- a/sasl_transport.go
+++ b/sasl_transport.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/apache/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/beltran/gosasl"
 )
 

--- a/sasl_transport_test.go
+++ b/sasl_transport_test.go
@@ -2,9 +2,10 @@ package gohive
 
 import (
 	"context"
-	"git.apache.org/thrift.git/lib/go/thrift"
 	"io"
 	"testing"
+
+	"github.com/apache/thrift.git/lib/go/thrift"
 )
 
 func TestSaslTransport(t *testing.T) {

--- a/sasl_transport_test.go
+++ b/sasl_transport_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/apache/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 func TestSaslTransport(t *testing.T) {


### PR DESCRIPTION
`git.apache.org` is not stable sometimes, this PR would use `github.com/apache/thrift` instead of `git.apache.org`. 

Timeout logs:
``` text
Processing triggers for systemd (229-4ubuntu21.22) ...
# cd .; git clone https://git.apache.org/thrift.git /go/src/git.apache.org/thrift.git
Cloning into '/go/src/git.apache.org/thrift.git'...
fatal: unable to access 'https://git.apache.org/thrift.git/': Failed to connect to git.apache.org port 443: Connection timed out
package git.apache.org/thrift.git/lib/go/thrift: exit status 128
```

From my travis-ci logs: https://travis-ci.com/sql-machine-learning/sqlflow/builds/125335154