### PR TITLE
change maxLength to optional

### DIFF
--- a/sasl_transport.go
+++ b/sasl_transport.go
@@ -245,3 +245,8 @@ func (p *TSaslTransport) Flush(ctx context.Context) (err error) {
 func (p *TSaslTransport) RemainingBytes() uint64 {
 	return uint64(p.frameSize)
 }
+
+// SetMaxLength set the maxLength
+func (p *TSaslTransport) SetMaxLength(maxLength uint32) {
+	p.maxLength = maxLength
+}


### PR DESCRIPTION
I got an error `Incorrect frame size (842545458)` when I select a big frame size data.
I think maxLength should be optional for users.