### PR TITLE
Support hive dynamic discovery via Zookeeper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/apache/thrift v0.12.0
 	github.com/beltran/gosasl v0.0.0-20200326175049-9dfbcb61a4b3
 	github.com/beltran/gssapi v0.0.0-20200324152954-d86554db4bab // indirect
+	github.com/go-zookeeper/zk v1.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,7 @@ github.com/beltran/gosasl v0.0.0-20200324154900-112336fc0fc0 h1:7RimtNV6sZKfAfwW
 github.com/beltran/gosasl v0.0.0-20200324154900-112336fc0fc0/go.mod h1:Qx8cW6jkI8riyzmklj80kAIkv+iezFUTBiGU0qHhHes=
 github.com/beltran/gosasl v0.0.0-20200326175049-9dfbcb61a4b3 h1:q832ARlau2fGuPSJe3Cuahdf4iS4LdQOYWPINojTSLc=
 github.com/beltran/gosasl v0.0.0-20200326175049-9dfbcb61a4b3/go.mod h1:Qx8cW6jkI8riyzmklj80kAIkv+iezFUTBiGU0qHhHes=
-github.com/beltran/gssapi v0.0.0-20180807003338-598f9f3b2878 h1:3xXWpeNMPRcQlbGdyfIdBHh9eD5TQgMWlZlHZ2luTwo=
-github.com/beltran/gssapi v0.0.0-20180807003338-598f9f3b2878/go.mod h1:GLe4UoSyvJ3cVG+DVtKen5eAiaD8mAJFuV5PT3Eeg9Q=
 github.com/beltran/gssapi v0.0.0-20200324152954-d86554db4bab h1:ayfcn60tXOSYy5zUN1AMSTQo4nJCf7hrdzAVchpPst4=
 github.com/beltran/gssapi v0.0.0-20200324152954-d86554db4bab/go.mod h1:GLe4UoSyvJ3cVG+DVtKen5eAiaD8mAJFuV5PT3Eeg9Q=
+github.com/go-zookeeper/zk v1.0.1 h1:LmXNmSnkNsNKai+aDu6sHRr8ZJzIrHJo8z8Z4sm8cT8=
+github.com/go-zookeeper/zk v1.0.1/go.mod h1:gpJdHazfkmlg4V0rt0vYeHYJHSL8hHFwV0qOd+HRTJE=

--- a/hive.go
+++ b/hive.go
@@ -118,7 +118,6 @@ func Connect(host string, port int, auth string,
 			return nil, fmt.Errorf("no Hive server is registered in the specified Zookeeper namespace %s",
 				configuration.ZookeeperNamespace)
 		}
-		return nil, nil
 	} else {
 		return innerConnect(host, port, auth, configuration)
 	}

--- a/hive.go
+++ b/hive.go
@@ -5,9 +5,11 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os/user"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -15,9 +17,11 @@ import (
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/beltran/gohive/hiveserver"
 	"github.com/beltran/gosasl"
+	"github.com/go-zookeeper/zk"
 )
 
 const DEFAULT_FETCH_SIZE int64 = 1000
+const ZOOKEEPER_DEFAULT_NAMESPACE = "hiveserver2"
 
 // Connection holds the information for getting a cursor to hive
 type Connection struct {
@@ -48,6 +52,8 @@ type ConnectConfiguration struct {
 	TransportMode        string
 	HTTPPath             string
 	TLSConfig            *tls.Config
+	UseZookeeper         bool
+	ZookeeperNamespace   string
 }
 
 // NewConnectConfiguration returns a connect configuration, all with empty fields
@@ -62,11 +68,97 @@ func NewConnectConfiguration() *ConnectConfiguration {
 		TransportMode:        "binary",
 		HTTPPath:             "cliservice",
 		TLSConfig:            nil,
+		UseZookeeper:         false,
+		ZookeeperNamespace:   ZOOKEEPER_DEFAULT_NAMESPACE,
 	}
 }
 
 // Connect to hive server
 func Connect(host string, port int, auth string,
+	configuration *ConnectConfiguration) (conn *Connection, err error) {
+
+	if configuration.UseZookeeper {
+		// consider host as zookeeper quorum
+		zkHosts := strings.Split(host, ",")
+		for i, zkHost := range zkHosts {
+			if !strings.Contains(zkHost, ":") {
+				zkHosts[i] = fmt.Sprintf("%s:%d", zkHost, port)
+			}
+		}
+
+		zkConn, _, err := zk.Connect(zkHosts, time.Second)
+		if err != nil {
+			return nil, err
+		}
+
+		hsInfos, _, err := zkConn.Children("/" + configuration.ZookeeperNamespace)
+		if err != nil {
+			panic(err)
+		}
+		if len(hsInfos) > 0 {
+			nodes := parseHiveServer2Info(hsInfos)
+			rand.Shuffle(len(nodes), func(i, j int) {
+				nodes[i], nodes[j] = nodes[j], nodes[i]
+			})
+			for _, node := range nodes {
+				port, err := strconv.Atoi(node["port"])
+				if err != nil {
+					continue
+				}
+				conn, err := innerConnect(node["host"], port, auth, configuration)
+				if err != nil {
+					// Let's try to connect to the next one
+					continue
+				}
+				return conn, nil
+			}
+			return nil, fmt.Errorf("all Hive servers of the specified Zookeeper namespace %s are unavailable",
+				configuration.ZookeeperNamespace)
+		} else {
+			return nil, fmt.Errorf("no Hive server is registered in the specified Zookeeper namespace %s",
+				configuration.ZookeeperNamespace)
+		}
+		return nil, nil
+	} else {
+		return innerConnect(host, port, auth, configuration)
+	}
+}
+
+func parseHiveServer2Info(hsInfos []string) []map[string]string {
+	results := make([]map[string]string, len(hsInfos))
+	actualCount := 0
+
+	for _, hsInfo := range hsInfos {
+		validFormat := false
+		node := make(map[string]string)
+
+		for _, param := range strings.Split(hsInfo, ";") {
+			kvPair := strings.Split(param, "=")
+			if len(kvPair) < 2 {
+				break
+			}
+			if kvPair[0] == "serverUri" {
+				hostAndPort := strings.Split(kvPair[1], ":")
+				if len(hostAndPort) == 2 {
+					node["host"] = hostAndPort[0]
+					node["port"] = hostAndPort[1]
+					validFormat = len(node["host"]) != 0 && len(node["port"]) != 0
+				} else {
+					break
+				}
+			} else {
+				node[kvPair[0]] = kvPair[1]
+			}
+		}
+		if validFormat {
+			results[actualCount] = node
+			actualCount++
+		}
+	}
+	return results[0:actualCount]
+}
+
+func innerConnect(host string, port int, auth string,
 	configuration *ConnectConfiguration) (conn *Connection, err error) {
 
 	var socket thrift.TTransport

--- a/hive_test.go
+++ b/hive_test.go
@@ -266,7 +266,7 @@ func TestDescriptionAsync(t *testing.T) {
 
 func TestHiveProperties(t *testing.T) {
 	configuration := map[string]string{
-    "hadoop.madeup.one": "one",
+		"hadoop.madeup.one": "one",
 	}
 
 	connection, cursor := makeConnectionWithConfiguration(t, 1000, configuration)
@@ -1309,6 +1309,26 @@ func TestTypesWithNulls(t *testing.T) {
 	}
 
 	closeAll(t, connection, cursor)
+}
+
+func TestParseZookeeperHiveServer2Info(t *testing.T) {
+	children := []string{
+		"serverUri=x1.test.io:10000;version=2.3.2;sequence=0000000792",
+		"",
+		"serverUri=x2.test.io:10001;version=2.3.2;sequence=0000000794",
+		"serverUri=x3.test.io:10006;version=2.3.2;sequence=0000000791",
+		"serverUri=invalid.test.io;version=2.3.2;sequence=0000000791",
+		"invalid=invalid",
+	}
+	expected := []map[string]string{
+		map[string]string{"host": "x1.test.io", "port": "10000", "version": "2.3.2", "sequence": "0000000792"},
+		map[string]string{"host": "x2.test.io", "port": "10001", "version": "2.3.2", "sequence": "0000000794"},
+		map[string]string{"host": "x3.test.io", "port": "10006", "version": "2.3.2", "sequence": "0000000791"},
+	}
+	result := parseHiveServer2Info(children)
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("Expected : %+v, got: %+v", expected, result)
+	}
 }
 
 func prepareAllTypesTable(t *testing.T, cursor *Cursor) {


### PR DESCRIPTION
- When UseZookeeper option is true, host option is treated as zookeeper quorum.
- If ZookeeperNamespace option is not specified, "hiveserver2" is used as default.
- The list of hive servers from zookeeper is always shuffled to avoid hotspot.
   - It should try to connect to the next hiveserver2 of the server list when connecting to the current one is failed.
- The spec. of zookeeper parameters is here :  https://github.com/apache/hive/blob/master/service/src/java/org/apache/hive/service/server/HiveServer2.java#L669-L675