### PR TITLE
Set description to avoid multiples get metadata calls

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -849,6 +849,7 @@ func (c *Cursor) Description() [][]string {
 			m[i] = []string{column.ColumnName, typeDesc.PrimitiveEntry.Type.String()}
 		}
 	}
+	c.description = m
 	return m
 }
 


### PR DESCRIPTION
Hi, thanks for the package!

With this fix fetch speed of RowMap increased and works same as FetchOne.
Looks like missing set description in cursor.Description call.
Thanks!