### PR TITLE
Add FetchLogs function to return Hive Execution logs

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -13,7 +14,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"log"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/beltran/gohive/hiveserver"
@@ -511,9 +511,9 @@ func (c *Cursor) executeAsync(ctx context.Context, query string) {
 }
 
 // Poll returns the current status of the last operation
-func (c *Cursor) Poll(getProgres bool) (status *hiveserver.TGetOperationStatusResp) {
+func (c *Cursor) Poll(getProgress bool) (status *hiveserver.TGetOperationStatusResp) {
 	c.Err = nil
-	progressGet := getProgres
+	progressGet := getProgress
 	pollRequest := hiveserver.NewTGetOperationStatusReq()
 	pollRequest.OperationHandle = c.operationHandle
 	pollRequest.GetProgressUpdate = &progressGet
@@ -899,7 +899,7 @@ func (c *Cursor) Description() [][]string {
 	return m
 }
 
-// HasMore returns weather more rows can be fetched from the server
+// HasMore returns whether more rows can be fetched from the server
 func (c *Cursor) HasMore(ctx context.Context) bool {
 	c.Err = nil
 	if c.response == nil && c.state != _FINISHED {
@@ -907,7 +907,7 @@ func (c *Cursor) HasMore(ctx context.Context) bool {
 		return c.state != _FINISHED || c.totalRows != c.columnIndex
 	}
 	// *c.response.HasMoreRows is always false
-	// so it can be checked and another roundtrip has to be done if etra data has been added
+	// so it can be checked and another roundtrip has to be done if extra data has been added
 	if c.totalRows == c.columnIndex && c.state != _FINISHED {
 		c.Err = c.pollUntilData(ctx, 1)
 	}
@@ -1003,7 +1003,7 @@ func (c *Cursor) Cancel() {
 	return
 }
 
-// Close close the cursor
+// Close closes the cursor
 func (c *Cursor) Close() {
 	c.Err = c.resetState()
 }

--- a/hive_test.go
+++ b/hive_test.go
@@ -645,6 +645,25 @@ func TestFetchContext(t *testing.T) {
 	closeAll(t, connection, cursor)
 }
 
+func TestFetchLogs(t *testing.T) {
+	connection, cursor := prepareTable(t, 2, 1000)
+	cursor.Execute(context.Background(), "SELECT * FROM pokes", false)
+	if cursor.Error() != nil {
+		t.Fatal(cursor.Error())
+	}
+
+	logs := cursor.FetchLogs()
+	if logs == nil {
+		t.Fatal("Logs should not be nil")
+	}
+
+	if len(logs) == 0 {
+		t.Fatal("Logs should non-empty")
+	}
+
+	closeAll(t, connection, cursor)
+}
+
 func TestHasMoreContext(t *testing.T) {
 	connection, cursor := prepareTable(t, 2, 1)
 	cursor.Execute(context.Background(), "SELECT * FROM pokes", false)
@@ -690,7 +709,6 @@ func TestRowMap(t *testing.T) {
 
 	closeAll(t, connection, cursor)
 }
-
 
 func TestRowMapColumnRename(t *testing.T) {
 	connection, cursor := makeConnection(t, 1000)


### PR DESCRIPTION
Add support for `FetchResults` with `FetchType = 1` (e.g. Hive logs).
Also, fix some typos I found.

I'd also like to support streaming these logs out, possibly with a `ExecuteAndLog` function that takes a channel, and calls this function periodically (e.g. after calling `Poll` in `WaitForCompletion`). I'd love to hear your thoughts, or I can make a separate issue if needed.