### PR TITLE
Update FetchLogs function to return error

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -552,6 +552,7 @@ func (c *Cursor) FetchLogs() []string {
 
 	resp, err := c.conn.client.FetchResults(context.Background(), logRequest)
 	if err != nil {
+		c.Err = err
 		return nil
 	}
 
@@ -559,11 +560,8 @@ func (c *Cursor) FetchLogs() []string {
 	cols := resp.Results.GetColumns()
 	var logs []string
 
-	for i := 0; i < len(cols); i++ {
-		col := cols[i].StringVal.Values
-		for j := 0; j < len(col); j++ {
-			logs = append(logs, col[j])
-		}
+	for _, col := range cols {
+		logs = append(logs, col.StringVal.Values...)
 	}
 
 	return logs

--- a/hive_test.go
+++ b/hive_test.go
@@ -661,6 +661,10 @@ func TestFetchLogs(t *testing.T) {
 		t.Fatal("Logs should non-empty")
 	}
 
+	if c.Error() != nil {
+		t.Fatal("Error should be nil")
+	}
+
 	closeAll(t, connection, cursor)
 }
 


### PR DESCRIPTION
In #133 I added a `FetchLogs` function. After landing this function, I realized that if an error occurs, it gets lost. It's good to actually return it. I also cleaned up the logic in the same function, using the spread operator.

To not break the API, just attach the error to the cursor.