### PR TITLE
Error formatting not using fmt.Errorf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/apache/thrift v0.14.1
 	github.com/beltran/gosasl v0.0.0-20200715011608-d5475aebb293
 	github.com/go-zookeeper/zk v1.0.1
+	github.com/pkg/errors v0.9.1
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/beltran/gohive
 go 1.14
 
 require (
-	github.com/apache/thrift v0.14.0
+	github.com/apache/thrift v0.14.1
 	github.com/beltran/gosasl v0.0.0-20200715011608-d5475aebb293
 	github.com/go-zookeeper/zk v1.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/apache/thrift v0.14.0 h1:vqZ2DP42i8th2OsgCcYZkirtbzvpZEFx53LiWDJXIAs=
-github.com/apache/thrift v0.14.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.14.1 h1:Yh8v0hpCj63p5edXOLaqTJW0IJ1p+eMW6+YSOqw1d6s=
 github.com/apache/thrift v0.14.1/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/beltran/gosasl v0.0.0-20200715011608-d5475aebb293 h1:1wRvU44e78w7zJoynLqrXLKSI+VEFEaWmzyq5JdUx7I=
@@ -8,3 +6,5 @@ github.com/beltran/gssapi v0.0.0-20200324152954-d86554db4bab h1:ayfcn60tXOSYy5zU
 github.com/beltran/gssapi v0.0.0-20200324152954-d86554db4bab/go.mod h1:GLe4UoSyvJ3cVG+DVtKen5eAiaD8mAJFuV5PT3Eeg9Q=
 github.com/go-zookeeper/zk v1.0.1 h1:LmXNmSnkNsNKai+aDu6sHRr8ZJzIrHJo8z8Z4sm8cT8=
 github.com/go-zookeeper/zk v1.0.1/go.mod h1:gpJdHazfkmlg4V0rt0vYeHYJHSL8hHFwV0qOd+HRTJE=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/apache/thrift v0.14.0 h1:vqZ2DP42i8th2OsgCcYZkirtbzvpZEFx53LiWDJXIAs=
 github.com/apache/thrift v0.14.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apache/thrift v0.14.1 h1:Yh8v0hpCj63p5edXOLaqTJW0IJ1p+eMW6+YSOqw1d6s=
+github.com/apache/thrift v0.14.1/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/beltran/gosasl v0.0.0-20200715011608-d5475aebb293 h1:1wRvU44e78w7zJoynLqrXLKSI+VEFEaWmzyq5JdUx7I=
 github.com/beltran/gosasl v0.0.0-20200715011608-d5475aebb293/go.mod h1:Qx8cW6jkI8riyzmklj80kAIkv+iezFUTBiGU0qHhHes=
 github.com/beltran/gssapi v0.0.0-20200324152954-d86554db4bab h1:ayfcn60tXOSYy5zUN1AMSTQo4nJCf7hrdzAVchpPst4=

--- a/hive.go
+++ b/hive.go
@@ -893,7 +893,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 				*d = c.queue[i].BoolVal.Values[c.columnIndex]
 			}
 		} else {
-			c.Err = errors.Errorf("empty column %v", c.queue[i])
+			c.Err = errors.Errorf("Empty column %v", c.queue[i])
 			return
 		}
 	}

--- a/hive.go
+++ b/hive.go
@@ -1042,7 +1042,7 @@ func (c *Cursor) Cancel() {
 		return
 	}
 	if !success(responseCancel.GetStatus()) {
-		c.Err = errors.New("error closing the operation: " + responseCancel.Status.String())
+		c.Err = errors.New("Error closing the operation: " + responseCancel.Status.String())
 	}
 	return
 }
@@ -1108,10 +1108,10 @@ func getTotalRows(columns []*hiveserver.TColumn) (int, error) {
 		} else if el.IsSetStringVal() {
 			return len(el.StringVal.Values), nil
 		} else {
-			return -1, errors.Errorf("unrecognized column type %T", el)
+			return -1, errors.Errorf("Unrecognized column type %T", el)
 		}
 	}
-	return 0, errors.New("all columns seem empty")
+	return 0, errors.New("All columns seem empty")
 }
 
 type inMemoryCookieJar struct {

--- a/hive.go
+++ b/hive.go
@@ -19,6 +19,7 @@ import (
 	"github.com/beltran/gohive/hiveserver"
 	"github.com/beltran/gosasl"
 	"github.com/go-zookeeper/zk"
+	"github.com/pkg/errors"
 )
 
 const DEFAULT_FETCH_SIZE int64 = 1000
@@ -188,7 +189,7 @@ func innerConnect(host string, port int, auth string,
 	if configuration.Username == "" {
 		_user, err := user.Current()
 		if err != nil {
-			return nil, fmt.Errorf("Can't determine the username")
+			return nil, errors.New("determine the username")
 		}
 		configuration.Username = strings.Replace(_user.Name, " ", "", -1)
 	}
@@ -219,7 +220,7 @@ func innerConnect(host string, port int, auth string,
 				return nil, err
 			}
 			if len(token) == 0 {
-				return nil, fmt.Errorf("Gssapi init context returned an empty token. Probably the service is empty in the configuration")
+				return nil, errors.New("gssapi init context returned an empty token, probably the service is empty in the configuration")
 			}
 
 			httpClient, protocol, err := getHTTPClient(configuration)
@@ -246,7 +247,7 @@ func innerConnect(host string, port int, auth string,
 		if auth == "NOSASL" {
 			transport = thrift.NewTBufferedTransport(socket, 4096)
 			if transport == nil {
-				return nil, fmt.Errorf("BufferedTransport was nil")
+				return nil, errors.New("BufferedTransport was nil")
 			}
 		} else if auth == "NONE" || auth == "LDAP" || auth == "CUSTOM" {
 			saslConfiguration := map[string]string{"username": configuration.Username, "password": configuration.Password}
@@ -275,7 +276,7 @@ func innerConnect(host string, port int, auth string,
 			}
 		}
 	} else {
-		panic(fmt.Sprintf("Unrecognized transport mode %s", configuration.TransportMode))
+		panic("Unrecognized transport mode " + configuration.TransportMode)
 	}
 
 	protocolFactory := thrift.NewTBinaryProtocolFactoryDefault()
@@ -356,7 +357,7 @@ func (c *Connection) Close() error {
 		return err
 	}
 	if !success(responseClose.GetStatus()) {
-		return fmt.Errorf("Error closing the session: %s", responseClose.Status.String())
+		return errors.New("closing the session: " + responseClose.Status.String())
 	}
 	return nil
 }
@@ -419,7 +420,7 @@ func (c *Cursor) WaitForCompletion(ctx context.Context) {
 				if msg == nil {
 					*msg = fmt.Sprintf("gohive: operation in state (%v) without task status or error message", operationStatus.OperationState)
 				}
-				c.Err = fmt.Errorf(*msg)
+				c.Err = errors.New(*msg)
 			}
 			break
 		}
@@ -430,7 +431,7 @@ func (c *Cursor) WaitForCompletion(ctx context.Context) {
 		time.Sleep(time.Duration(time.Duration(c.conn.configuration.PollIntervalInMillis)) * time.Millisecond)
 		mux.Lock()
 		if contextDone {
-			c.Err = fmt.Errorf("Context was done before the query was executed")
+			c.Err = errors.New("context was done before the query was executed")
 			c.state = _CONTEXT_DONE
 			mux.Unlock()
 			return
@@ -462,7 +463,7 @@ func (c *Cursor) Execute(ctx context.Context, query string, async bool) {
 			if c.state == _CONTEXT_DONE {
 				c.handleDoneContext()
 			} else if c.state == _ERROR {
-				c.Err = fmt.Errorf("Probably the context was over when passed to execute. This probably resulted in the message being sent but we didn't get an operation handle so it's most likely a bug in thrift")
+				c.Err = errors.New("probably the context was over when passed to execute. This probably resulted in the message being sent but we didn't get an operation handle so it's most likely a bug in thrift")
 			}
 			return
 		}
@@ -509,7 +510,7 @@ func (c *Cursor) executeAsync(ctx context.Context, query string) {
 	}
 	if !success(responseExecute.GetStatus()) {
 		c.Err = HiveError{
-			error:     fmt.Errorf("Error while executing query: %s", responseExecute.Status.String()),
+			error:     errors.New("executing query: " + responseExecute.Status.String()),
 			ErrorCode: int(*responseExecute.Status.ErrorCode),
 		}
 		return
@@ -535,7 +536,7 @@ func (c *Cursor) Poll(getProgress bool) (status *hiveserver.TGetOperationStatusR
 		return nil
 	}
 	if !success(responsePoll.GetStatus()) {
-		c.Err = fmt.Errorf("Error closing the operation: %s", responsePoll.Status.String())
+		c.Err = errors.New("closing the operation: " + responsePoll.Status.String())
 		return nil
 	}
 	return responsePoll
@@ -588,7 +589,7 @@ func (c *Cursor) fetchIfEmpty(ctx context.Context) {
 	if c.totalRows == c.columnIndex {
 		c.queue = nil
 		if !c.HasMore(ctx) {
-			c.Err = fmt.Errorf("No more rows are left")
+			c.Err = errors.New("no more rows are left")
 			return
 		}
 		if c.Err != nil {
@@ -724,7 +725,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 	}
 
 	if len(c.queue) != len(dests) {
-		c.Err = fmt.Errorf("%d arguments where passed for filling but the number of columns is %d", len(dests), len(c.queue))
+		c.Err = errors.Errorf("%d arguments where passed for filling but the number of columns is %d", len(dests), len(c.queue))
 		return
 	}
 	for i := 0; i < len(c.queue); i++ {
@@ -735,7 +736,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			}
 			d, ok := dests[i].(*[]byte)
 			if !ok {
-				c.Err = fmt.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].BinaryVal.Values[c.columnIndex], c.queue[i].BinaryVal.Values[c.columnIndex])
+				c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].BinaryVal.Values[c.columnIndex], c.queue[i].BinaryVal.Values[c.columnIndex])
 				return
 			}
 			if isNull(c.queue[i].BinaryVal.Nulls, c.columnIndex) {
@@ -752,7 +753,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**int8)
 				if !ok {
-					c.Err = fmt.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].ByteVal.Values[c.columnIndex], c.queue[i].ByteVal.Values[c.columnIndex])
+					c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].ByteVal.Values[c.columnIndex], c.queue[i].ByteVal.Values[c.columnIndex])
 					return
 				}
 
@@ -774,7 +775,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**int16)
 				if !ok {
-					c.Err = fmt.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].I16Val.Values[c.columnIndex], c.queue[i].I16Val.Values[c.columnIndex])
+					c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].I16Val.Values[c.columnIndex], c.queue[i].I16Val.Values[c.columnIndex])
 					return
 				}
 
@@ -795,7 +796,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**int32)
 				if !ok {
-					c.Err = fmt.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].I32Val.Values[c.columnIndex], c.queue[i].I32Val.Values[c.columnIndex])
+					c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].I32Val.Values[c.columnIndex], c.queue[i].I32Val.Values[c.columnIndex])
 					return
 				}
 
@@ -816,7 +817,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**int64)
 				if !ok {
-					c.Err = fmt.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].I64Val.Values[c.columnIndex], c.queue[i].I64Val.Values[c.columnIndex])
+					c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].I64Val.Values[c.columnIndex], c.queue[i].I64Val.Values[c.columnIndex])
 					return
 				}
 
@@ -837,7 +838,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**string)
 				if !ok {
-					c.Err = fmt.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].StringVal.Values[c.columnIndex], c.queue[i].StringVal.Values[c.columnIndex])
+					c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].StringVal.Values[c.columnIndex], c.queue[i].StringVal.Values[c.columnIndex])
 					return
 				}
 
@@ -858,7 +859,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**float64)
 				if !ok {
-					c.Err = fmt.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].DoubleVal.Values[c.columnIndex], c.queue[i].DoubleVal.Values[c.columnIndex])
+					c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].DoubleVal.Values[c.columnIndex], c.queue[i].DoubleVal.Values[c.columnIndex])
 					return
 				}
 
@@ -879,7 +880,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**bool)
 				if !ok {
-					c.Err = fmt.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].BoolVal.Values[c.columnIndex], c.queue[i].BoolVal.Values[c.columnIndex])
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].BoolVal.Values[c.columnIndex], c.queue[i].BoolVal.Values[c.columnIndex])
 					return
 				}
 
@@ -892,7 +893,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 				*d = c.queue[i].BoolVal.Values[c.columnIndex]
 			}
 		} else {
-			c.Err = fmt.Errorf("Empty column %v", c.queue[i])
+			c.Err = errors.Errorf("Empty column %v", c.queue[i])
 			return
 		}
 	}
@@ -918,7 +919,7 @@ func (c *Cursor) Description() [][]string {
 		return c.description
 	}
 	if c.operationHandle == nil {
-		c.Err = fmt.Errorf("Description can only be called after after a Poll or after an async request")
+		c.Err = errors.Errorf("description can only be called after after a Poll or after an async request")
 	}
 
 	metaRequest := hiveserver.NewTGetResultSetMetadataReq()
@@ -929,7 +930,7 @@ func (c *Cursor) Description() [][]string {
 		return nil
 	}
 	if metaResponse.Status.StatusCode != hiveserver.TStatusCode_SUCCESS_STATUS {
-		c.Err = fmt.Errorf(metaResponse.Status.String())
+		c.Err = errors.New(metaResponse.Status.String())
 		return nil
 	}
 	m := make([][]string, len(metaResponse.Schema.Columns))
@@ -989,7 +990,7 @@ func (c *Cursor) pollUntilData(ctx context.Context, n int) (err error) {
 			c.response = responseFetch
 
 			if responseFetch.Status.StatusCode != hiveserver.TStatusCode_SUCCESS_STATUS {
-				rowsAvailable <- fmt.Errorf(responseFetch.Status.String())
+				rowsAvailable <- errors.New(responseFetch.Status.String())
 				return
 			}
 			err = c.parseResults(responseFetch)
@@ -1016,7 +1017,7 @@ func (c *Cursor) pollUntilData(ctx context.Context, n int) (err error) {
 		// Wait for goroutine to finish
 		case <-rowsAvailable:
 		}
-		err = fmt.Errorf("Context is done")
+		err = errors.New("context is done")
 	}
 
 	if err != nil {
@@ -1024,7 +1025,7 @@ func (c *Cursor) pollUntilData(ctx context.Context, n int) (err error) {
 	}
 
 	if len(c.queue) < n {
-		return fmt.Errorf("Only %d rows where received", len(c.queue))
+		return errors.Errorf("only %d rows where received", len(c.queue))
 	}
 	return nil
 }
@@ -1041,7 +1042,7 @@ func (c *Cursor) Cancel() {
 		return
 	}
 	if !success(responseCancel.GetStatus()) {
-		c.Err = fmt.Errorf("Error closing the operation: %s", responseCancel.Status.String())
+		c.Err = errors.New("Error closing the operation: " + responseCancel.Status.String())
 	}
 	return
 }
@@ -1070,7 +1071,7 @@ func (c *Cursor) resetState() error {
 			return err
 		}
 		if !success(responseClose.GetStatus()) {
-			return fmt.Errorf("Error closing the operation: %s", responseClose.Status.String())
+			return errors.New("closing the operation: " + responseClose.Status.String())
 		}
 		return nil
 	}
@@ -1110,7 +1111,7 @@ func getTotalRows(columns []*hiveserver.TColumn) (int, error) {
 			return -1, fmt.Errorf("Unrecognized column type %T", el)
 		}
 	}
-	return 0, fmt.Errorf("All columns seem empty")
+	return 0, errors.New("all columns seem empty")
 }
 
 type inMemoryCookieJar struct {

--- a/hive.go
+++ b/hive.go
@@ -189,7 +189,7 @@ func innerConnect(host string, port int, auth string,
 	if configuration.Username == "" {
 		_user, err := user.Current()
 		if err != nil {
-			return nil, errors.New("determine the username")
+			return nil, errors.New("Can't determine the username")
 		}
 		configuration.Username = strings.Replace(_user.Name, " ", "", -1)
 	}
@@ -220,7 +220,7 @@ func innerConnect(host string, port int, auth string,
 				return nil, err
 			}
 			if len(token) == 0 {
-				return nil, errors.New("gssapi init context returned an empty token, probably the service is empty in the configuration")
+				return nil, errors.New("Gssapi init context returned an empty token. Probably the service is empty in the configuration")
 			}
 
 			httpClient, protocol, err := getHTTPClient(configuration)
@@ -357,7 +357,7 @@ func (c *Connection) Close() error {
 		return err
 	}
 	if !success(responseClose.GetStatus()) {
-		return errors.New("closing the session: " + responseClose.Status.String())
+		return errors.New("Error closing the session: " + responseClose.Status.String())
 	}
 	return nil
 }
@@ -431,7 +431,7 @@ func (c *Cursor) WaitForCompletion(ctx context.Context) {
 		time.Sleep(time.Duration(time.Duration(c.conn.configuration.PollIntervalInMillis)) * time.Millisecond)
 		mux.Lock()
 		if contextDone {
-			c.Err = errors.New("context was done before the query was executed")
+			c.Err = errors.New("Context was done before the query was executed")
 			c.state = _CONTEXT_DONE
 			mux.Unlock()
 			return
@@ -463,7 +463,7 @@ func (c *Cursor) Execute(ctx context.Context, query string, async bool) {
 			if c.state == _CONTEXT_DONE {
 				c.handleDoneContext()
 			} else if c.state == _ERROR {
-				c.Err = errors.New("probably the context was over when passed to execute. This probably resulted in the message being sent but we didn't get an operation handle so it's most likely a bug in thrift")
+				c.Err = errors.New("Probably the context was over when passed to execute. This probably resulted in the message being sent but we didn't get an operation handle so it's most likely a bug in thrift")
 			}
 			return
 		}
@@ -510,7 +510,7 @@ func (c *Cursor) executeAsync(ctx context.Context, query string) {
 	}
 	if !success(responseExecute.GetStatus()) {
 		c.Err = HiveError{
-			error:     errors.New("executing query: " + responseExecute.Status.String()),
+			error:     errors.New("Error while executing query: " + responseExecute.Status.String()),
 			ErrorCode: int(*responseExecute.Status.ErrorCode),
 		}
 		return
@@ -536,7 +536,7 @@ func (c *Cursor) Poll(getProgress bool) (status *hiveserver.TGetOperationStatusR
 		return nil
 	}
 	if !success(responsePoll.GetStatus()) {
-		c.Err = errors.New("closing the operation: " + responsePoll.Status.String())
+		c.Err = errors.New("Error closing the operation: " + responsePoll.Status.String())
 		return nil
 	}
 	return responsePoll
@@ -589,7 +589,7 @@ func (c *Cursor) fetchIfEmpty(ctx context.Context) {
 	if c.totalRows == c.columnIndex {
 		c.queue = nil
 		if !c.HasMore(ctx) {
-			c.Err = errors.New("no more rows are left")
+			c.Err = errors.New("No more rows are left")
 			return
 		}
 		if c.Err != nil {
@@ -736,7 +736,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			}
 			d, ok := dests[i].(*[]byte)
 			if !ok {
-				c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].BinaryVal.Values[c.columnIndex], c.queue[i].BinaryVal.Values[c.columnIndex])
+				c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].BinaryVal.Values[c.columnIndex], c.queue[i].BinaryVal.Values[c.columnIndex])
 				return
 			}
 			if isNull(c.queue[i].BinaryVal.Nulls, c.columnIndex) {
@@ -753,7 +753,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**int8)
 				if !ok {
-					c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].ByteVal.Values[c.columnIndex], c.queue[i].ByteVal.Values[c.columnIndex])
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].ByteVal.Values[c.columnIndex], c.queue[i].ByteVal.Values[c.columnIndex])
 					return
 				}
 
@@ -775,7 +775,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**int16)
 				if !ok {
-					c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].I16Val.Values[c.columnIndex], c.queue[i].I16Val.Values[c.columnIndex])
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].I16Val.Values[c.columnIndex], c.queue[i].I16Val.Values[c.columnIndex])
 					return
 				}
 
@@ -796,7 +796,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**int32)
 				if !ok {
-					c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].I32Val.Values[c.columnIndex], c.queue[i].I32Val.Values[c.columnIndex])
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].I32Val.Values[c.columnIndex], c.queue[i].I32Val.Values[c.columnIndex])
 					return
 				}
 
@@ -817,7 +817,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**int64)
 				if !ok {
-					c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].I64Val.Values[c.columnIndex], c.queue[i].I64Val.Values[c.columnIndex])
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].I64Val.Values[c.columnIndex], c.queue[i].I64Val.Values[c.columnIndex])
 					return
 				}
 
@@ -838,7 +838,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**string)
 				if !ok {
-					c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].StringVal.Values[c.columnIndex], c.queue[i].StringVal.Values[c.columnIndex])
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].StringVal.Values[c.columnIndex], c.queue[i].StringVal.Values[c.columnIndex])
 					return
 				}
 
@@ -859,7 +859,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**float64)
 				if !ok {
-					c.Err = errors.Errorf("unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].DoubleVal.Values[c.columnIndex], c.queue[i].DoubleVal.Values[c.columnIndex])
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T)", dests[i], c.queue[i].DoubleVal.Values[c.columnIndex], c.queue[i].DoubleVal.Values[c.columnIndex])
 					return
 				}
 
@@ -919,7 +919,7 @@ func (c *Cursor) Description() [][]string {
 		return c.description
 	}
 	if c.operationHandle == nil {
-		c.Err = errors.Errorf("description can only be called after after a Poll or after an async request")
+		c.Err = errors.Errorf("Description can only be called after after a Poll or after an async request")
 	}
 
 	metaRequest := hiveserver.NewTGetResultSetMetadataReq()
@@ -1017,7 +1017,7 @@ func (c *Cursor) pollUntilData(ctx context.Context, n int) (err error) {
 		// Wait for goroutine to finish
 		case <-rowsAvailable:
 		}
-		err = errors.New("context is done")
+		err = errors.New("Context is done")
 	}
 
 	if err != nil {
@@ -1025,7 +1025,7 @@ func (c *Cursor) pollUntilData(ctx context.Context, n int) (err error) {
 	}
 
 	if len(c.queue) < n {
-		return errors.Errorf("only %d rows where received", len(c.queue))
+		return errors.Errorf("Only %d rows where received", len(c.queue))
 	}
 	return nil
 }
@@ -1071,7 +1071,7 @@ func (c *Cursor) resetState() error {
 			return err
 		}
 		if !success(responseClose.GetStatus()) {
-			return errors.New("closing the operation: " + responseClose.Status.String())
+			return errors.New("Error closing the operation: " + responseClose.Status.String())
 		}
 		return nil
 	}

--- a/hive_test.go
+++ b/hive_test.go
@@ -617,8 +617,8 @@ func TestIsRow(t *testing.T) {
 		if cursor.Error() == nil {
 			t.Fatal("Error shouldn't be nil")
 		}
-		if cursor.Err.Error() != "no more rows are left" {
-			t.Fatal("Error should be 'no more rows are left'")
+		if cursor.Err.Error() != "No more rows are left" {
+			t.Fatal("Error should be 'No more rows are left'")
 		}
 	}
 

--- a/sasl_transport.go
+++ b/sasl_transport.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/beltran/gosasl"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -106,7 +107,7 @@ func (p *TSaslTransport) Open() (err error) {
 			}
 			break
 		} else {
-			return thrift.NewTTransportExceptionFromError(fmt.Errorf("Bad SASL negotiation status: %d (%s)", status, challenge))
+			return thrift.NewTTransportExceptionFromError(errors.Errorf("Bad SASL negotiation status: %d (%s)", status, challenge))
 		}
 	}
 	return nil

--- a/sasl_transport.go
+++ b/sasl_transport.go
@@ -103,11 +103,11 @@ func (p *TSaslTransport) Open() (err error) {
 			p.sendSaslMsg(p.OpeningContext, OK, proccessed)
 		} else if status == COMPLETE {
 			if !p.saslClient.Complete() {
-				return thrift.NewTTransportException(thrift.NOT_OPEN, "the server erroneously indicated that SASL negotiation was complete")
+				return thrift.NewTTransportException(thrift.NOT_OPEN, "The server erroneously indicated that SASL negotiation was complete")
 			}
 			break
 		} else {
-			return thrift.NewTTransportExceptionFromError(errors.Errorf("bad SASL negotiation status: %d (%s)", status, challenge))
+			return thrift.NewTTransportExceptionFromError(errors.Errorf("Bad SASL negotiation status: %d (%s)", status, challenge))
 		}
 	}
 	return nil


### PR DESCRIPTION
1.  In [golang wiki](https://github.com/golang/go/wiki/CodeReviewComments#error-strings), the document recommends to not use capitalization in error string except some edge cases.
2.  Don't need to assign error value with string messages using `%v`, `+` is simpler.
3.  fmt.Errorf always need more calculation than assigning error value with errors.New
4.  github.com/pkg/errors provide simple error handlings.