### PR TITLE
fix: avoid panic if the type of dest[i] is pointer to pointer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ To differentiate between these two values (`NULL` and `0`) the following will se
 var i *int32 = new(int32)
 cursor.FetchOne(context.Background(), &i)
 ```
+which will produce the same result as:
+```
+var i *int32
+cursor.FetchOne(context.Background(), &i)
+```
 Alternatively, using the rowmap API, `m := cursor.RowMap(context.Background())`,
  `m` would be `map[string]interface{}{"table_name.column_name": nil}` for a `NULL` value. It will return a map
 where the keys are `table_name.column_name`. This works fine with hive but using [Spark Thirft SQL server](https://spark.apache.org/docs/latest/sql-distributed-sql-engine.html) `table_name` is not present and the keys are `column_name` and it can [lead to problems](https://github.com/beltran/gohive/issues/120) if two tables have the same column name so the `FetchOne` API should be used in this case.

--- a/hive.go
+++ b/hive.go
@@ -819,7 +819,7 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			}
 			d, ok := dests[i].(*[]byte)
 			if !ok {
-				c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].BinaryVal.Values[c.columnIndex], c.queue[i].BinaryVal.Values[c.columnIndex],i)
+				c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].BinaryVal.Values[c.columnIndex], c.queue[i].BinaryVal.Values[c.columnIndex], i)
 				return
 			}
 			if isNull(c.queue[i].BinaryVal.Nulls, c.columnIndex) {
@@ -836,13 +836,16 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**int8)
 				if !ok {
-					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].ByteVal.Values[c.columnIndex], c.queue[i].ByteVal.Values[c.columnIndex],i)
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].ByteVal.Values[c.columnIndex], c.queue[i].ByteVal.Values[c.columnIndex], i)
 					return
 				}
 
 				if isNull(c.queue[i].ByteVal.Nulls, c.columnIndex) {
 					*d = nil
 				} else {
+					if *d == nil {
+						*d = new(int8)
+					}
 					**d = c.queue[i].ByteVal.Values[c.columnIndex]
 				}
 			} else {
@@ -858,13 +861,16 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**int16)
 				if !ok {
-					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].I16Val.Values[c.columnIndex], c.queue[i].I16Val.Values[c.columnIndex],i)
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].I16Val.Values[c.columnIndex], c.queue[i].I16Val.Values[c.columnIndex], i)
 					return
 				}
 
 				if isNull(c.queue[i].I16Val.Nulls, c.columnIndex) {
 					*d = nil
 				} else {
+					if *d == nil {
+						*d = new(int16)
+					}
 					**d = c.queue[i].I16Val.Values[c.columnIndex]
 				}
 			} else {
@@ -879,13 +885,16 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**int32)
 				if !ok {
-					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].I32Val.Values[c.columnIndex], c.queue[i].I32Val.Values[c.columnIndex],i)
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].I32Val.Values[c.columnIndex], c.queue[i].I32Val.Values[c.columnIndex], i)
 					return
 				}
 
 				if isNull(c.queue[i].I32Val.Nulls, c.columnIndex) {
 					*d = nil
 				} else {
+					if *d == nil {
+						*d = new(int32)
+					}
 					**d = c.queue[i].I32Val.Values[c.columnIndex]
 				}
 			} else {
@@ -900,13 +909,16 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**int64)
 				if !ok {
-					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].I64Val.Values[c.columnIndex], c.queue[i].I64Val.Values[c.columnIndex],i)
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].I64Val.Values[c.columnIndex], c.queue[i].I64Val.Values[c.columnIndex], i)
 					return
 				}
 
 				if isNull(c.queue[i].I64Val.Nulls, c.columnIndex) {
 					*d = nil
 				} else {
+					if *d == nil {
+						*d = new(int64)
+					}
 					**d = c.queue[i].I64Val.Values[c.columnIndex]
 				}
 			} else {
@@ -921,13 +933,16 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**string)
 				if !ok {
-					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].StringVal.Values[c.columnIndex], c.queue[i].StringVal.Values[c.columnIndex],i)
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].StringVal.Values[c.columnIndex], c.queue[i].StringVal.Values[c.columnIndex], i)
 					return
 				}
 
 				if isNull(c.queue[i].StringVal.Nulls, c.columnIndex) {
 					*d = nil
 				} else {
+					if *d == nil {
+						*d = new(string)
+					}
 					**d = c.queue[i].StringVal.Values[c.columnIndex]
 				}
 			} else {
@@ -942,13 +957,16 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**float64)
 				if !ok {
-					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].DoubleVal.Values[c.columnIndex], c.queue[i].DoubleVal.Values[c.columnIndex],i)
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].DoubleVal.Values[c.columnIndex], c.queue[i].DoubleVal.Values[c.columnIndex], i)
 					return
 				}
 
 				if isNull(c.queue[i].DoubleVal.Nulls, c.columnIndex) {
 					*d = nil
 				} else {
+					if *d == nil {
+						*d = new(float64)
+					}
 					**d = c.queue[i].DoubleVal.Values[c.columnIndex]
 				}
 			} else {
@@ -963,13 +981,16 @@ func (c *Cursor) FetchOne(ctx context.Context, dests ...interface{}) {
 			if !ok {
 				d, ok := dests[i].(**bool)
 				if !ok {
-					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].BoolVal.Values[c.columnIndex], c.queue[i].BoolVal.Values[c.columnIndex],i)
+					c.Err = errors.Errorf("Unexpected data type %T for value %v (should be %T) index is %v", dests[i], c.queue[i].BoolVal.Values[c.columnIndex], c.queue[i].BoolVal.Values[c.columnIndex], i)
 					return
 				}
 
 				if isNull(c.queue[i].BoolVal.Nulls, c.columnIndex) {
 					*d = nil
 				} else {
+					if *d == nil {
+						*d = new(bool)
+					}
 					**d = c.queue[i].BoolVal.Values[c.columnIndex]
 				}
 			} else {

--- a/hive_test.go
+++ b/hive_test.go
@@ -1688,6 +1688,43 @@ func TestTypesWithPointer(t *testing.T) {
 	closeAll(t, connection, cursor)
 }
 
+func TestTypesWithoutPointer(t *testing.T) {
+	connection, cursor := makeConnection(t, 1000)
+	prepareAllTypesTable(t, cursor)
+	var b bool
+	var tinyInt *int8
+	var smallInt *int16
+	var normalInt *int32
+	var bigInt *int64
+	var floatType *float64
+	var double *float64
+	var s *string
+	var timeStamp *string
+	var binary []byte
+	var array *string
+	var mapType *string
+	var structType *string
+	var union *string
+	var decimal *string
+
+	cursor.Execute(context.Background(), "SELECT * FROM all_types", false)
+	if cursor.Error() != nil {
+		t.Fatal(cursor.Error())
+	}
+
+	cursor.FetchOne(context.Background(), &b, &tinyInt, &smallInt, &normalInt, &bigInt,
+		&floatType, &double, &s, &timeStamp, &binary, &array, &mapType, &structType, &union, &decimal)
+	if cursor.Err != nil {
+		t.Fatal(cursor.Err)
+	}
+
+	if *tinyInt != 127 || *smallInt != 32767 || *bigInt != 9223372036854775807 || binary == nil || *array != "[1,2]" || *s != "a string" {
+		t.Fatalf("Unexpected value, tinyInt: %d, smallInt: %d, bigInt: %d, binary: %x, array: %s, s: %s", *tinyInt, *smallInt, *bigInt, binary, *array, *s)
+	}
+
+	closeAll(t, connection, cursor)
+}
+
 func TestTypesWithNulls(t *testing.T) {
 	connection, cursor := makeConnection(t, 1000)
 	prepareAllTypesTableWithNull(t, cursor)

--- a/hive_test.go
+++ b/hive_test.go
@@ -1688,7 +1688,7 @@ func TestTypesWithPointer(t *testing.T) {
 	closeAll(t, connection, cursor)
 }
 
-func TestTypesWithoutPointer(t *testing.T) {
+func TestTypesWithoutInitializedPointer(t *testing.T) {
 	connection, cursor := makeConnection(t, 1000)
 	prepareAllTypesTable(t, cursor)
 	var b bool


### PR DESCRIPTION
When I passed a pointer of nil pointer to FetchOne for assining, there will be a panic.
like 
```go
a := struct {
  A *int
}{}
cursor.FeachOne(context.BackGround(), &a.A)
```
I don't want to init every pointer in the struct