### PR TITLE
Bump to Thrift 0.16

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -207,20 +207,18 @@ func innerConnect(ctx context.Context, host string, port int, auth string,
 		}
 	} else {
 		if configuration.TLSConfig != nil {
-			socket, err = thrift.NewTSSLSocketConf(addr, &thrift.TConfiguration{
+			socket = thrift.NewTSSLSocketConf(addr, &thrift.TConfiguration{
 				ConnectTimeout: configuration.ConnectTimeout,
 				SocketTimeout:  configuration.SocketTimeout,
 				TLSConfig:      configuration.TLSConfig,
 			})
 		} else {
-			socket, err = thrift.NewTSocketConf(addr, &thrift.TConfiguration{
+			socket = thrift.NewTSocketConf(addr, &thrift.TConfiguration{
 				ConnectTimeout: configuration.ConnectTimeout,
 				SocketTimeout:  configuration.SocketTimeout,
 			})
 		}
-		if err != nil {
-			return
-		}
+
 		if err = socket.Open(); err != nil {
 			return
 		}


### PR DESCRIPTION
As part of some yak shaving work to make [usql](https://github.com/xo/usql) work for Hive, I have fixed some API issues with the given version of thrift, `thrift.NewTSocketConf`  no longer returns a (socket, error) pair any more