### PR TITLE
Add close function for zk connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ hive.jks
 dhive
 client.cer.key
 client.cer.pem
+
+# .idea
+.idea/

--- a/hive.go
+++ b/hive.go
@@ -106,6 +106,7 @@ func ConnectZookeeper(hosts string, auth string,
 	if err != nil {
 		return nil, err
 	}
+	defer zkConn.Close()
 
 	hsInfos, _, err := zkConn.Children("/" + configuration.ZookeeperNamespace)
 	if err != nil {


### PR DESCRIPTION
### Issue
There is no close function for the zk connection, causing a socket leak.

<hr>

Please review when you are available.
Thanks!