### PR TITLE
Support cookies in http ldap connections (#237)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/beltran/gosasl v0.0.0-20240109120436-e08f7517fc34
 	github.com/go-zookeeper/zk v1.0.1
 	github.com/pkg/errors v0.9.1
+	golang.org/x/net v0.14.0
 )
 
 require github.com/beltran/gssapi v0.0.0-20200324152954-d86554db4bab // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,3 +10,4 @@ github.com/go-zookeeper/zk v1.0.1 h1:LmXNmSnkNsNKai+aDu6sHRr8ZJzIrHJo8z8Z4sm8cT8
 github.com/go-zookeeper/zk v1.0.1/go.mod h1:gpJdHazfkmlg4V0rt0vYeHYJHSL8hHFwV0qOd+HRTJE=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+golang.org/x/net v0.14.0 h1:BONx9s002vGdD9umnlX1Po8vOZmrgH34qlHcD1MfK14=

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -42,9 +42,9 @@ function install_deps() {
     sed -i.bak 's/tez_version.*/tez_version = 0.9.2/g' ./config/hive.cfg
     sed -i.bak 's/tez_version.*/tez_version = 0.9.2/g' ./config/hive_and_kerberos.cfg
     sed -i.bak 's/tez_version.*/tez_version = 0.9.2/g' ./config/hive_and_metastore_and_kerberos.cfg
-    sed -i.bak 's/hive_version.*/hive_version = 3.1.2/g' ./config/hive.cfg
-    sed -i.bak 's/hive_version.*/hive_version = 3.1.2/g' ./config/hive_and_kerberos.cfg
-    sed -i.bak 's/hive_version.*/hive_version = 3.1.2/g' ./config/hive_and_metastore_and_kerberos.cfg
+    sed -i.bak 's/hive_version.*/hive_version = 3.1.3/g' ./config/hive.cfg
+    sed -i.bak 's/hive_version.*/hive_version = 3.1.3/g' ./config/hive_and_kerberos.cfg
+    sed -i.bak 's/hive_version.*/hive_version = 3.1.3/g' ./config/hive_and_metastore_and_kerberos.cfg
     sed -i.bak 's/hadoop_version.*/hadoop_version = 2.10.2/g' ./config/hive.cfg
     sed -i.bak 's/hadoop_version.*/hadoop_version = 2.10.2/g' ./config/hive_and_kerberos.cfg
     sed -i.bak 's/hadoop_version.*/hadoop_version = 2.10.2/g' ./config/hive_and_metastore_and_kerberos.cfg


### PR DESCRIPTION
Support cookies in http ldap connections. 

We have been running code from then forked package since beginning of the year and we have not seen issues related to this patch. 

closes #237 