### PR TITLE
feat(v2): add HiveConnector for programmatic database/sql connection

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -108,10 +108,12 @@ function  binaryKerberos() {
   export METASTORE_SKIP="0"
   go test -tags "integration kerberos" -covermode=count -coverprofile=a.part -v -run . || { echo "Failed TRANSPORT=$TRANSPORT, AUTH=$AUTH, SSL=$SSL" ; docker logs hs2.example ; exit 2; }
   go run -tags "kerberos" example/main.go
+  go run -tags "kerberos" example/main_connector.go
   go run -tags "kerberos" example/main_meta.go
   pushd v2
   go test -tags "integration kerberos" -covermode=count -coverprofile=aa.part -v -run . || { echo "Failed TRANSPORT=$TRANSPORT, AUTH=$AUTH, SSL=$SSL" ; docker logs hs2.example ; exit 2; }
   go run -tags "kerberos" example/main.go
+  go run -tags "kerberos" example/main_connector.go
   go run -tags "kerberos" example/main_meta.go
   popd
 }

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -110,9 +110,9 @@ function  binaryKerberos() {
   go run -tags "kerberos" example/main.go
   go run -tags "kerberos" example/main_meta.go
   pushd v2
+  go run -tags "kerberos" example/main_connector.go
   go test -tags "integration kerberos" -covermode=count -coverprofile=aa.part -v -run . || { echo "Failed TRANSPORT=$TRANSPORT, AUTH=$AUTH, SSL=$SSL" ; docker logs hs2.example ; exit 2; }
   go run -tags "kerberos" example/main.go
-  go run -tags "kerberos" example/main_connector.go
   go run -tags "kerberos" example/main_meta.go
   popd
 }

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -108,7 +108,6 @@ function  binaryKerberos() {
   export METASTORE_SKIP="0"
   go test -tags "integration kerberos" -covermode=count -coverprofile=a.part -v -run . || { echo "Failed TRANSPORT=$TRANSPORT, AUTH=$AUTH, SSL=$SSL" ; docker logs hs2.example ; exit 2; }
   go run -tags "kerberos" example/main.go
-  go run -tags "kerberos" example/main_connector.go
   go run -tags "kerberos" example/main_meta.go
   pushd v2
   go test -tags "integration kerberos" -covermode=count -coverprofile=aa.part -v -run . || { echo "Failed TRANSPORT=$TRANSPORT, AUTH=$AUTH, SSL=$SSL" ; docker logs hs2.example ; exit 2; }

--- a/v2/README.md
+++ b/v2/README.md
@@ -139,6 +139,95 @@ This implies setting in hive-site.xml:
 - `hive.server2.transport.mode = http`
 - `hive.server2.thrift.http.port = 10001`
 
+## Programmatic Connection (HiveConnector)
+
+Instead of building a DSN string, you can use `HiveConnector` with a structured `Config`. This is useful when integrating with GORM or when connection parameters come from application config.
+
+### Basic usage
+``` go
+import gohive "github.com/beltran/gohive/v2"
+
+db := gohive.OpenDB(gohive.Config{
+    Host:     "hs2.example.com",
+    Port:     10000,
+    Auth:     "NONE",
+    Username: "hive",
+    Password: "hive",
+    Database: "default",
+})
+defer db.Close()
+```
+
+### With CA certificate (server verification)
+``` go
+import gohive "github.com/beltran/gohive/v2"
+
+db := gohive.OpenDB(gohive.Config{
+    Host:      "hs2.example.com",
+    Port:      10000,
+    Auth:      "NONE",
+    Username:  "hive",
+    Password:  "hive",
+    Database:  "default",
+    SSLCAFile: "/path/to/ca-cert.crt",
+})
+defer db.Close()
+```
+
+### With client certificate and key (mutual TLS)
+``` go
+import gohive "github.com/beltran/gohive/v2"
+
+db := gohive.OpenDB(gohive.Config{
+    Host:            "hs2.example.com",
+    Port:            10000,
+    Auth:            "NONE",
+    Username:        "hive",
+    Password:        "hive",
+    Database:        "default",
+    SSLCertFile:     "/path/to/client-cert.pem",
+    SSLKeyFile:      "/path/to/client-key.pem",
+    SSLInsecureSkip: false,
+})
+defer db.Close()
+```
+
+### With custom TLS config
+For full control over TLS settings, provide your own `*tls.Config`:
+``` go
+import (
+    "crypto/tls"
+    "crypto/x509"
+    "os"
+
+    gohive "github.com/beltran/gohive/v2"
+)
+
+caPEM, _ := os.ReadFile("/path/to/ca-cert.crt")
+caPool := x509.NewCertPool()
+caPool.AppendCertsFromPEM(caPEM)
+
+clientCert, _ := tls.LoadX509KeyPair("/path/to/client-cert.pem", "/path/to/client-key.pem")
+
+db := gohive.OpenDB(gohive.Config{
+    Host:     "hs2.example.com",
+    Port:     10000,
+    Auth:     "NONE",
+    Username: "hive",
+    Password: "hive",
+    Database: "default",
+    TLSConfig: &tls.Config{
+        RootCAs:            caPool,
+        Certificates:       []tls.Certificate{clientCert},
+        InsecureSkipVerify: false,
+        MinVersion:         tls.VersionTLS12,
+    },
+})
+defer db.Close()
+```
+
+> **Note:** When `TLSConfig` is provided directly, `SSLCertFile`, `SSLKeyFile`, `SSLCAFile`, and `SSLInsecureSkip` are ignored.
+
 ## Connection to the Hive Metastore
 
 The thrift client is directly exposed, so the API exposed by the Hive metastore can be called directly.

--- a/v2/connector.go
+++ b/v2/connector.go
@@ -59,6 +59,9 @@ func (c *HiveConnector) Connect(ctx context.Context) (driver.Conn, error) {
 		connCfg.HTTPPath = c.cfg.HTTPPath
 	}
 	connCfg.Service = c.cfg.Service
+	if connCfg.Service = "" {
+		connCfg.Service = "hive"
+	}
 	connCfg.TLSConfig = c.cfg.TLSConfig
 	connCfg.HiveConfiguration = c.cfg.HiveConfiguration
 

--- a/v2/connector.go
+++ b/v2/connector.go
@@ -52,7 +52,9 @@ func (c *HiveConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	connCfg.Username = c.cfg.Username
 	connCfg.Password = c.cfg.Password
 	connCfg.Database = c.cfg.Database
-	connCfg.TransportMode = c.cfg.TransportMode
+	if c.cfg.TransportMode != "" {
+	    connCfg.TransportMode = c.cfg.TransportMode
+	}
 	if c.cfg.HTTPPath != "" {
 		connCfg.HTTPPath = c.cfg.HTTPPath
 	}

--- a/v2/connector.go
+++ b/v2/connector.go
@@ -29,6 +29,8 @@ type Config struct {
 	HiveConfiguration map[string]string
 }
 
+var _ driver.Connector = (*HiveConnector)(nil)
+
 // HiveConnector implements driver.Connector using gohive v2 under the hood.
 type HiveConnector struct {
 	cfg Config
@@ -80,8 +82,10 @@ func (c *HiveConnector) Connect(ctx context.Context) (driver.Conn, error) {
 			}
 			connCfg.TLSConfig = &tls.Config{
 				RootCAs:            pool,
-				InsecureSkipVerify: false,
+				InsecureSkipVerify: c.cfg.SSLInsecureSkip,
 			}
+		} else if c.cfg.SSLInsecureSkip {
+			connCfg.TLSConfig = &tls.Config{InsecureSkipVerify: true}
 		}
 	}
 

--- a/v2/connector.go
+++ b/v2/connector.go
@@ -1,0 +1,98 @@
+package gohive
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"os"
+)
+
+// Config holds everything needed to connect to Hive/Impala via gohive v2.
+type Config struct {
+	Host              string
+	Port              int
+	Auth              string // "NONE", "KERBEROS", "NOSASL", etc.
+	Username          string
+	Password          string
+	Database          string
+	TransportMode     string // "binary" or "http"
+	HTTPPath          string
+	Service           string // Kerberos service name
+	TLSConfig         *tls.Config
+	SSLCertFile       string
+	SSLKeyFile        string
+	SSLCAFile         string
+	SSLInsecureSkip   bool
+	HiveConfiguration map[string]string
+}
+
+// HiveConnector implements driver.Connector using gohive v2 under the hood.
+type HiveConnector struct {
+	cfg Config
+}
+
+// NewConnector creates a new HiveConnector with the given config.
+func NewConnector(cfg Config) *HiveConnector {
+	return &HiveConnector{cfg: cfg}
+}
+
+// OpenDB is a convenience that returns a *sql.DB ready for use with GORM.
+func OpenDB(cfg Config) *sql.DB {
+	return sql.OpenDB(NewConnector(cfg))
+}
+
+// Connect establishes a new connection using gohive v2.
+func (c *HiveConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	connCfg := newConnectConfiguration()
+	connCfg.Username = c.cfg.Username
+	connCfg.Password = c.cfg.Password
+	connCfg.Database = c.cfg.Database
+	connCfg.TransportMode = c.cfg.TransportMode
+	if c.cfg.HTTPPath != "" {
+		connCfg.HTTPPath = c.cfg.HTTPPath
+	}
+	connCfg.Service = c.cfg.Service
+	connCfg.TLSConfig = c.cfg.TLSConfig
+	connCfg.HiveConfiguration = c.cfg.HiveConfiguration
+
+	// Fallback: build TLS config from cert/key files if TLSConfig not provided directly
+	if connCfg.TLSConfig == nil {
+
+		if c.cfg.SSLCertFile != "" && c.cfg.SSLKeyFile != "" {
+			tlsConfig, err := getTlsConfiguration(c.cfg.SSLCertFile, c.cfg.SSLKeyFile)
+			if err != nil {
+				return nil, fmt.Errorf("failed to configure SSL: %v", err)
+			}
+			tlsConfig.InsecureSkipVerify = c.cfg.SSLInsecureSkip
+			connCfg.TLSConfig = tlsConfig
+		} else if c.cfg.SSLCAFile != "" {
+
+			caPEM, err := os.ReadFile(c.cfg.SSLCAFile)
+			if err != nil {
+				return nil, fmt.Errorf("invalid ca path: %s (%w)", c.cfg.SSLCAFile, err)
+			}
+			pool := x509.NewCertPool()
+			if !pool.AppendCertsFromPEM(caPEM) {
+				return nil, fmt.Errorf("invalid certification %q", c.cfg.SSLCAFile)
+			}
+			connCfg.TLSConfig = &tls.Config{
+				RootCAs:            pool,
+				InsecureSkipVerify: false,
+			}
+		}
+	}
+
+	conn, err := connect(ctx, c.cfg.Host, c.cfg.Port, c.cfg.Auth, connCfg)
+	if err != nil {
+		return nil, fmt.Errorf("gohive connect: %w", err)
+	}
+	return &sqlConnection{conn: conn}, nil
+}
+
+// Driver returns a placeholder driver (unused by sql.OpenDB).
+func (c *HiveConnector) Driver() driver.Driver {
+	return &Driver{}
+}

--- a/v2/connector.go
+++ b/v2/connector.go
@@ -59,7 +59,7 @@ func (c *HiveConnector) Connect(ctx context.Context) (driver.Conn, error) {
 		connCfg.HTTPPath = c.cfg.HTTPPath
 	}
 	connCfg.Service = c.cfg.Service
-	if connCfg.Service = "" {
+	if connCfg.Service == "" {
 		connCfg.Service = "hive"
 	}
 	connCfg.TLSConfig = c.cfg.TLSConfig

--- a/v2/connector_test.go
+++ b/v2/connector_test.go
@@ -1,0 +1,243 @@
+package gohive
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewConnector(t *testing.T) {
+	cfg := Config{
+		Host:     "localhost",
+		Port:     10000,
+		Auth:     "NONE",
+		Username: "user",
+		Password: "pass",
+		Database: "mydb",
+	}
+	c := NewConnector(cfg)
+	if c == nil {
+		t.Fatal("expected non-nil connector")
+	}
+	if c.cfg.Host != "localhost" {
+		t.Errorf("got host %q, want %q", c.cfg.Host, "localhost")
+	}
+	if c.cfg.Port != 10000 {
+		t.Errorf("got port %d, want %d", c.cfg.Port, 10000)
+	}
+	if c.cfg.Database != "mydb" {
+		t.Errorf("got database %q, want %q", c.cfg.Database, "mydb")
+	}
+}
+
+func TestOpenDB(t *testing.T) {
+	cfg := Config{
+		Host: "localhost",
+		Port: 10000,
+		Auth: "NONE",
+	}
+	db := OpenDB(cfg)
+	if db == nil {
+		t.Fatal("expected non-nil *sql.DB")
+	}
+	db.Close()
+}
+
+func TestConnectorDriver(t *testing.T) {
+	c := NewConnector(Config{})
+	d := c.Driver()
+	if d == nil {
+		t.Fatal("expected non-nil driver")
+	}
+	if _, ok := d.(*Driver); !ok {
+		t.Fatalf("expected *Driver, got %T", d)
+	}
+}
+
+func TestConnectorHTTPPathDefault(t *testing.T) {
+	connCfg := newConnectConfiguration()
+	cfg := Config{} // HTTPPath empty
+	if cfg.HTTPPath != "" {
+		connCfg.HTTPPath = cfg.HTTPPath
+	}
+	if connCfg.HTTPPath != "cliservice" {
+		t.Errorf("got HTTPPath %q, want %q", connCfg.HTTPPath, "cliservice")
+	}
+}
+
+func TestConnectorHTTPPathCustom(t *testing.T) {
+	connCfg := newConnectConfiguration()
+	cfg := Config{HTTPPath: "custom/path"}
+	if cfg.HTTPPath != "" {
+		connCfg.HTTPPath = cfg.HTTPPath
+	}
+	if connCfg.HTTPPath != "custom/path" {
+		t.Errorf("got HTTPPath %q, want %q", connCfg.HTTPPath, "custom/path")
+	}
+}
+
+func TestConnectorHiveConfiguration(t *testing.T) {
+	hiveConf := map[string]string{
+		"hive.server2.thrift.sasl.qop": "auth-conf",
+		"mapreduce.job.queuename":      "default",
+	}
+	connCfg := newConnectConfiguration()
+	connCfg.HiveConfiguration = hiveConf
+
+	if len(connCfg.HiveConfiguration) != 2 {
+		t.Fatalf("expected 2 hive config entries, got %d", len(connCfg.HiveConfiguration))
+	}
+	if connCfg.HiveConfiguration["hive.server2.thrift.sasl.qop"] != "auth-conf" {
+		t.Error("hive config key not set correctly")
+	}
+}
+
+func TestConnectorTLSConfigDirect(t *testing.T) {
+	customTLS := &tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS13,
+	}
+	connCfg := newConnectConfiguration()
+	connCfg.TLSConfig = customTLS
+
+	if connCfg.TLSConfig != customTLS {
+		t.Error("expected custom TLSConfig to be used directly")
+	}
+	if connCfg.TLSConfig.MinVersion != tls.VersionTLS13 {
+		t.Error("expected MinVersion TLS 1.3")
+	}
+}
+
+func TestConnectorSSLCertKeyFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	certFile := filepath.Join(tmpDir, "test.pem")
+	keyFile := filepath.Join(tmpDir, "test.key")
+
+	certPEM, keyPEM := generateSelfSignedCert(t)
+	if err := os.WriteFile(certFile, certPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, keyPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{
+		SSLCertFile:     certFile,
+		SSLKeyFile:      keyFile,
+		SSLInsecureSkip: true,
+	}
+
+	connCfg := newConnectConfiguration()
+	// Simulate Connect logic
+	if connCfg.TLSConfig == nil && cfg.SSLCertFile != "" && cfg.SSLKeyFile != "" {
+		tlsConfig, err := getTlsConfiguration(cfg.SSLCertFile, cfg.SSLKeyFile)
+		if err != nil {
+			t.Fatalf("getTlsConfiguration failed: %v", err)
+		}
+		tlsConfig.InsecureSkipVerify = cfg.SSLInsecureSkip
+		connCfg.TLSConfig = tlsConfig
+	}
+
+	if connCfg.TLSConfig == nil {
+		t.Fatal("expected TLSConfig to be built from cert/key files")
+	}
+	if !connCfg.TLSConfig.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify to be true")
+	}
+	if len(connCfg.TLSConfig.Certificates) == 0 {
+		t.Error("expected at least one certificate")
+	}
+}
+
+func TestConnectorSSLCAFileFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	caFile := filepath.Join(tmpDir, "ca.crt")
+
+	caCert, _ := generateSelfSignedCert(t)
+	if err := os.WriteFile(caFile, caCert, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{SSLCAFile: caFile}
+
+	connCfg := newConnectConfiguration()
+	if connCfg.TLSConfig == nil && cfg.SSLCertFile == "" && cfg.SSLCAFile != "" {
+		caPEM, err := os.ReadFile(cfg.SSLCAFile)
+		if err != nil {
+			t.Fatalf("failed to read CA file: %v", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			t.Fatal("failed to append CA cert")
+		}
+		connCfg.TLSConfig = &tls.Config{
+			RootCAs:            pool,
+			InsecureSkipVerify: false,
+		}
+	}
+
+	if connCfg.TLSConfig == nil {
+		t.Fatal("expected TLSConfig to be built from CA file")
+	}
+	if connCfg.TLSConfig.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify to be false")
+	}
+	if connCfg.TLSConfig.RootCAs == nil {
+		t.Error("expected RootCAs to be set")
+	}
+}
+
+func TestConnectorSSLInvalidCertPath(t *testing.T) {
+	_, err := getTlsConfiguration("/nonexistent/cert.pem", "/nonexistent/key.pem")
+	if err == nil {
+		t.Fatal("expected error for nonexistent cert/key files")
+	}
+}
+
+func TestConnectorSSLInvalidCAPath(t *testing.T) {
+	_, err := os.ReadFile("/nonexistent/ca.crt")
+	if err == nil {
+		t.Fatal("expected error for nonexistent CA file")
+	}
+}
+
+// generateSelfSignedCert creates a self-signed certificate and key PEM for testing.
+func generateSelfSignedCert(t *testing.T) (certPEM, keyPEM []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal key: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return certPEM, keyPEM
+}

--- a/v2/example/main_connector.go
+++ b/v2/example/main_connector.go
@@ -25,7 +25,7 @@ func main() {
 	}
 
 	// Create a test table
-	_, err = db.Exec("CREATE TABLE IF NOT EXISTS test_table (id INT, name STRING)")
+	_, err := db.Exec("CREATE TABLE IF NOT EXISTS test_table (id INT, name STRING)")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/v2/example/main_connector.go
+++ b/v2/example/main_connector.go
@@ -15,8 +15,6 @@ func main() {
 		Host:     "hs2.example.com",
 		Port:     10000,
 		Auth:     "KERBEROS",
-		Username: "hive",
-		Password: "hive",
 		Database: "default",
 	})
 	defer db.Close()

--- a/v2/example/main_connector.go
+++ b/v2/example/main_connector.go
@@ -24,6 +24,18 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Create a test table
+	_, err = db.Exec("CREATE TABLE IF NOT EXISTS test_table (id INT, name STRING)")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Insert some test data
+	_, err = db.Exec("INSERT INTO test_table VALUES(1, 'test1'), (2, 'test2'), (3, 'test3')")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Execute a query
 	rows, err := db.Query("SELECT * FROM test_table LIMIT 10")
 	if err != nil {

--- a/v2/example/main_connector.go
+++ b/v2/example/main_connector.go
@@ -14,7 +14,7 @@ func main() {
 	db := gohive.OpenDB(gohive.Config{
 		Host:     "hs2.example.com",
 		Port:     10000,
-		Auth:     "NONE",
+		Auth:     "KERBEROS",
 		Username: "hive",
 		Password: "hive",
 		Database: "default",

--- a/v2/example/main_connector.go
+++ b/v2/example/main_connector.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	gohive "github.com/beltran/gohive/v2"
+)
+
+func main() {
+	// Using HiveConnector with programmatic config (no DSN string needed).
+	// This is useful for GORM integration or when you already have
+	// connection parameters as structured config.
+	db := gohive.OpenDB(gohive.Config{
+		Host:     "hs2.example.com",
+		Port:     10000,
+		Auth:     "NONE",
+		Username: "hive",
+		Password: "hive",
+		Database: "default",
+	})
+	defer db.Close()
+
+	// Test the connection
+	if err := db.Ping(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Execute a query
+	rows, err := db.Query("SELECT * FROM test_table LIMIT 10")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	values := make([]interface{}, len(columns))
+	valuePtrs := make([]interface{}, len(columns))
+	for i := range columns {
+		valuePtrs[i] = &values[i]
+	}
+
+	for rows.Next() {
+		if err := rows.Scan(valuePtrs...); err != nil {
+			log.Fatal(err)
+		}
+		for i, col := range columns {
+			fmt.Printf("%s: %v\n", col, values[i])
+		}
+		fmt.Println("---")
+	}
+
+	if err := rows.Err(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/v2/example/main_connector_ssl.go
+++ b/v2/example/main_connector_ssl.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"os"
+
+	gohive "github.com/beltran/gohive/v2"
+)
+
+func main() {
+	// Example 1: Using CA certificate only (server verification)
+	exampleWithCAFile()
+
+	// Example 2: Using client cert + key (mutual TLS)
+	exampleWithCertAndKey()
+
+	// Example 3: Using custom *tls.Config directly
+	exampleWithCustomTLSConfig()
+}
+
+// exampleWithCAFile connects using a CA certificate to verify the server.
+func exampleWithCAFile() {
+	db := gohive.OpenDB(gohive.Config{
+		Host:      "hs2.example.com",
+		Port:      10000,
+		Auth:      "NONE",
+		Username:  "hive",
+		Password:  "hive",
+		Database:  "default",
+		SSLCAFile: "/path/to/ca-cert.pem",
+	})
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		log.Fatal("CA cert example:", err)
+	}
+	fmt.Println("Connected with CA certificate")
+}
+
+// exampleWithCertAndKey connects using client certificate and key (mTLS).
+func exampleWithCertAndKey() {
+	db := gohive.OpenDB(gohive.Config{
+		Host:            "hs2.example.com",
+		Port:            10000,
+		Auth:            "NONE",
+		Username:        "hive",
+		Password:        "hive",
+		Database:        "default",
+		SSLCertFile:     "/path/to/client-cert.pem",
+		SSLKeyFile:      "/path/to/client-key.pem",
+		SSLInsecureSkip: false,
+	})
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		log.Fatal("mTLS example:", err)
+	}
+	fmt.Println("Connected with client cert + key")
+}
+
+// exampleWithCustomTLSConfig connects using a user-provided *tls.Config.
+// This gives full control over TLS settings.
+func exampleWithCustomTLSConfig() {
+	// Load CA cert
+	caPEM, err := os.ReadFile("/path/to/ca-cert.pem")
+	if err != nil {
+		log.Fatal(err)
+	}
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caPEM) {
+		log.Fatal("failed to append CA cert")
+	}
+
+	// Load client cert + key
+	clientCert, err := tls.LoadX509KeyPair("/path/to/client-cert.pem", "/path/to/client-key.pem")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	db := gohive.OpenDB(gohive.Config{
+		Host:     "hs2.example.com",
+		Port:     10000,
+		Auth:     "NONE",
+		Username: "hive",
+		Password: "hive",
+		Database: "default",
+		TLSConfig: &tls.Config{
+			RootCAs:            caPool,
+			Certificates:       []tls.Certificate{clientCert},
+			InsecureSkipVerify: false,
+			MinVersion:         tls.VersionTLS12,
+		},
+	})
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		log.Fatal("custom TLS example:", err)
+	}
+	fmt.Println("Connected with custom TLS config")
+}


### PR DESCRIPTION
## feat(v2): Add `HiveConnector` for programmatic `database/sql` connection

### Summary

This PR introduces `HiveConnector`, a new `driver.Connector` implementation for gohive v2 that allows creating `database/sql` connections using a structured `Config` struct instead of DSN strings.

### Motivation

The existing `Driver.OpenConnector` only accepts DSN strings, which can be cumbersome when connection parameters are already available as structured config (e.g., from environment variables, config files, or frameworks like GORM). `HiveConnector` provides a cleaner programmatic API via `sql.OpenDB()`.

### Changes

- Add `Config` struct with all connection parameters (host, port, auth, TLS, Hive configuration, etc.)
- Add `HiveConnector` implementing `driver.Connector` interface
- Add `NewConnector(cfg Config)` and `OpenDB(cfg Config)` convenience functions
- Support three TLS modes:
  - Direct `*tls.Config` passthrough for full control
  - Client cert + key files (mTLS)
  - CA certificate file (server verification)
- Add comprehensive unit tests (`connector_test.go`)
- Add usage examples: basic connection and SSL variants

### Usage

```go
db := gohive.OpenDB(gohive.Config{
    Host:     "hs2.example.com",
    Port:     10000,
    Auth:     "NONE",
    Username: "hive",
    Database: "default",
})
defer db.Close()
```

### Files Changed

- `v2/connector.go` — new `HiveConnector` implementation
- `v2/connector_test.go` — unit tests
- `v2/example/main_connector.go` — basic usage example
- `v2/example/main_connector_ssl.go` — SSL usage examples
